### PR TITLE
Tickets/DM-48567: add S11 mode to FAM

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -3,6 +3,15 @@
 ##################
 Version History
 ##################
+
+.._lsst.ts.donut.viz-1.6.0
+
+-------------
+1.6.0
+-------------
+
+* Add S11-only mode for LsstCam Full Array Mode.
+
 .._lsst.ts.donut.viz-1.5.0
 
 -------------


### PR DESCRIPTION
Add  a config to `PlotDonutTask` that allows to only plot the center raft detector for FAM mode:
<img width="902" alt="image" src="https://github.com/user-attachments/assets/c6f51d52-934d-46c0-be9a-28ac4fda473d" />
