### PR TITLE
Tickets/DM-52628: add band to aggregated metadata

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -4,6 +4,15 @@
 Version History
 ##################
 
+.._lsst.ts.donut.viz-2.2.3
+
+-------------
+2.2.3
+-------------
+
+* Add band propagation to metadata in AggregateZernikeTablesTask.
+
+
 .._lsst.ts.donut.viz-2.2.2
 
 -------------

--- a/python/lsst/donut/viz/aggregate_visit.py
+++ b/python/lsst/donut/viz/aggregate_visit.py
@@ -144,6 +144,8 @@ class AggregateZernikeTablesTask(pipeBase.PipelineTask):
         meta["dec"] = table_meta["extra"]["boresight_dec_rad"]
         meta["az"] = table_meta["extra"]["boresight_az_rad"]
         meta["alt"] = table_meta["extra"]["boresight_alt_rad"]
+        meta["band"] = table_meta["extra"]["band"]
+
         # Average mjds
         meta["mjd"] = 0.5 * (table_meta["extra"]["mjd"] + table_meta["intra"]["mjd"])
         meta["nollIndices"] = noll_indices

--- a/tests/test_donut_viz_pipeline_cwfs_sensors.py
+++ b/tests/test_donut_viz_pipeline_cwfs_sensors.py
@@ -47,6 +47,7 @@ class TestDonutVizPipeline(TestCase):
             "rotTelPos",
             "visit",
             "nollIndices",
+            "band",
         ]
 
         cls.butler = Butler(cls.test_repo_dir)
@@ -136,6 +137,7 @@ class TestDonutVizPipeline(TestCase):
         self.assertCountEqual(agg_donut_table.meta.keys(), ["visitInfo"])
         donut_meta_keys = self.meta_keys + ["focusZ"]
         donut_meta_keys.remove("nollIndices")
+        donut_meta_keys.remove("band")  # this is not present in donutTable
         self.assertCountEqual(agg_donut_table.meta["visitInfo"].keys(), donut_meta_keys)
 
     def testAggregateDonutStamps(self):

--- a/tests/test_donut_viz_pipeline_science_sensors.py
+++ b/tests/test_donut_viz_pipeline_science_sensors.py
@@ -45,6 +45,7 @@ class TestDonutVizPipeline(TestCase):
             "rotTelPos",
             "visit",
             "nollIndices",
+            "band",
         ]
 
         cls.butler = Butler(cls.test_repo_dir)
@@ -131,6 +132,7 @@ class TestDonutVizPipeline(TestCase):
         )
         donut_meta_keys = self.meta_keys + ["focusZ"]
         donut_meta_keys.remove("nollIndices")
+        donut_meta_keys.remove("band")  # not in donutTable metadata
         for key in ["extra", "intra"]:
             self.assertCountEqual(agg_donut_table.meta[key].keys(), donut_meta_keys)
         donut_meta_keys.remove("focusZ")


### PR DESCRIPTION
This ticket adds `band` to `aggregateZernikesRaw`, `aggregateZernikesAvg`),   `aggregateAOSVisitTableRaw`, `aggregateAOSVisitTableAvg`. 