### PR TITLE
[RSO-822]: Changed the maxRefObjects for astrometry task in refitWCS pipeline

### DIFF
--- a/doc/news/RSO-800.feature.md
+++ b/doc/news/RSO-800.feature.md
@@ -1,0 +1,1 @@
+Added danish v1.2 support. Added functionality for plotDonutFits to just use the danish model saved in the zernikes metadata.

--- a/doc/news/RSO-822.feature.md
+++ b/doc/news/RSO-822.feature.md
@@ -1,0 +1,1 @@
+Changed the maxRefObjects for astrometry task in refitWCS pipeline down to 2048 from the default 8192 to speed up crowded fields.

--- a/pipelines/_ingredients/wepRefitWcsCwfsPipeline.yaml
+++ b/pipelines/_ingredients/wepRefitWcsCwfsPipeline.yaml
@@ -27,7 +27,7 @@ tasks:
       astromTask.referenceSelector.magLimit.fluxField: "phot_rp_mean_flux"
       astromTask.maxIter: 5
       astromTask.matcher.maxOffsetPix: 1000
-      # astromTask.matcher.maxRotationDeg: 1.0
+      astromTask.matcher.maxRefObjects: 2048
       failTask: False
       # Settings to use to add blended donuts
       # donutSelector.unblendedSeparation: 160


### PR DESCRIPTION
Reduced it down to 2048 from the default 8192 to speed up crowded fields.