### PR TITLE
Tickets/RSO-827: fix plotDonutFits stamp labels

### DIFF
--- a/doc/news/RSO-827.bugfix.md
+++ b/doc/news/RSO-827.bugfix.md
@@ -1,0 +1,1 @@
+Fixed labeling error in plotDonutFits switching to axis fractional coordinates.

--- a/python/lsst/donut/viz/plot_aos_task.py
+++ b/python/lsst/donut/viz/plot_aos_task.py
@@ -1510,18 +1510,38 @@ class PlotDonutFitsTask(pipeBase.PipelineTask):
 
         vmax = np.nanquantile(imgs[0], 0.99)
         axs[0].imshow(imgs[0], cmap=cmap, vmin=-vmax / 10, vmax=vmax)
-        axs[0].text(5, 150, f"blur: {blur:5.3f}")
+        axs[0].text(
+            0.05, 0.05, f"blur: {blur:5.3f}", transform=axs[0].transAxes, fontsize="small", va="bottom"
+        )
         axs[1].imshow(models[0], cmap=cmap, vmin=-vmax / 10, vmax=vmax)
-        axs[1].text(5, 150, f"id:           {row['intra_donut_id'][-3:]}", fontsize="small")
+        axs[1].text(
+            0.05,
+            0.05,
+            f"id:  {row['intra_donut_id'][-3:]}",
+            transform=axs[1].transAxes,
+            fontsize="small",
+            va="bottom",
+        )
         axs[2].imshow(imgs[0] - models[0], cmap="bwr", vmin=-vmax / 3, vmax=vmax / 3)
         _, _, ttl_res = self.computeResidualStats(imgs[0], models[0])
-        axs[2].text(5, 150, f"res: {ttl_res:5.3f}")
+        axs[2].text(
+            0.05, 0.05, f"res:  {ttl_res:5.3f}", transform=axs[2].transAxes, fontsize="small", va="bottom"
+        )
         axs[3].imshow(imgs[1], cmap=cmap, vmin=-vmax / 10, vmax=vmax)
         axs[4].imshow(models[1], cmap=cmap, vmin=-vmax / 10, vmax=vmax)
-        axs[4].text(5, 150, f"id:           {row['extra_donut_id'][-3:]}", fontsize="small")
+        axs[4].text(
+            0.05,
+            0.05,
+            f"id:  {row['extra_donut_id'][-3:]}",
+            transform=axs[4].transAxes,
+            fontsize="small",
+            va="bottom",
+        )
         axs[5].imshow(imgs[1] - models[1], cmap="bwr", vmin=-vmax / 3, vmax=vmax / 3)
         _, _, ttl_res = self.computeResidualStats(imgs[1], models[1])
-        axs[5].text(5, 150, f"res: {ttl_res:5.3f}")
+        axs[5].text(
+            0.05, 0.05, f"res:  {ttl_res:5.3f}", transform=axs[5].transAxes, fontsize="small", va="bottom"
+        )
         axs[6].bar(row.meta["nollIndices"], row["zk_CCS"], color="k")
         axs[6].axhline(0, color="k", lw=0.5)
         axs[6].set_ylim(self.config.zkYmin, self.config.zkYmax)


### PR DESCRIPTION
Use axes-relative coordinates for the stamp text instead of data coordinates to work regardless of binning used. Before: 
<img width="1400" height="1980" alt="unknown" src="https://github.com/user-attachments/assets/ea62f803-b454-4fbf-b357-ea890497b5f5" />
  After:  
<img width="1400" height="1980" alt="unknown" src="https://github.com/user-attachments/assets/4a7e5cda-dd6b-4bab-88bb-9fbb44338ea0" />
